### PR TITLE
Check and error message for unequal number of rows in $add_data

### DIFF
--- a/R/Leafdown.R
+++ b/R/Leafdown.R
@@ -277,6 +277,16 @@ Leafdown <- R6::R6Class("Leafdown",
       metadata_initial <- private$.curr_spdf@data
       metadata_given <- data[, names(private$.curr_spdf@data)]
 
+      n_row_metadata_given <- nrow(metadata_given)
+      n_row_metadata_initial <- nrow(metadata_initial)
+      if (n_row_metadata_given != n_row_metadata_initial) {
+        err_msg <- sprintf(
+          "The number of rows of the given data (%1.0f) is not equal to the number of rows of the initial data (%1.0f).",
+          n_row_metadata_given, n_row_metadata_initial
+        )
+        stop(err_msg)
+      }
+
       # use of !isTRUE is intentional, as all.equal returns either TRUE or gives an error message (do not change to isFALSE)
       if (!isTRUE(all.equal(metadata_given, metadata_initial, check.attributes = FALSE))) {
         stop(paste("You cannot change or reorder the existing meta-data. Only add to it. Use left_joins to avoid reordering.",

--- a/tests/testthat/test-add_data.R
+++ b/tests/testthat/test-add_data.R
@@ -41,22 +41,30 @@ test_that("Missing columns in data throws error", {
 
   # change data
   # random col to delete
-  col <- floor(runif(1, min=1, max=dim(data)[2]))
+  col <- floor(runif(1, min = 1, max = dim(data)[2]))
   data <- data[, -col]
 
   expect_error(my_leafdown$add_data(data), "You cannot remove columns from the existing meta-data. Only add to it")
 })
 
-test_that("Missing row in data throws error", {
+test_that("Unequal number of rows as meta-data throws an error", {
   my_leafdown <- init_leafdown()
   data <- my_leafdown$curr_data
 
-  # change data
-  # random col and row for change
-  row <- floor(runif(1, min=1, max=dim(data)[1]))
-  data <- data[-row, ]
+  data_too_long <- data
+  data_too_long[nrow(data_too_long) + 1, ] <- data_too_long[1, ]
+  err_msg_too_long <- sprintf(
+    "The number of rows of the given data \\(52\\) is not equal to the number of rows of the initial data \\(51\\)"
+  )
 
-  expect_error(my_leafdown$add_data(data), "You cannot change or reorder the existing meta-data. Only add to it. Use left_joins to avoid reordering")
+  data_too_short <- data
+  data_too_short <- data_too_short[-1, ]
+  err_msg_too_short <- c(
+    "The number of rows of the given data \\(50\\) is not equal to the number of rows of the initial data \\(51\\)"
+  )
+
+  expect_error(my_leafdown$add_data(data_too_long), regexp = err_msg_too_long)
+  expect_error(my_leafdown$add_data(data_too_short), err_msg_too_short)
 })
 
 test_that("Reordering Data throws correct error", {


### PR DESCRIPTION
Adds check and implicit error message if the number of rows of given data is not equal to the number of rows of initial data

#36