### PR TITLE
Don't reduce data.frame to a vector if only one column is selected (fixes #38)

### DIFF
--- a/R/Leafdown.R
+++ b/R/Leafdown.R
@@ -275,7 +275,7 @@ Leafdown <- R6::R6Class("Leafdown",
       }
 
       metadata_initial <- private$.curr_spdf@data
-      metadata_given <- data[, names(private$.curr_spdf@data)]
+      metadata_given <- data[, names(private$.curr_spdf@data), drop = FALSE]
 
       n_row_metadata_given <- nrow(metadata_given)
       n_row_metadata_initial <- nrow(metadata_initial)


### PR DESCRIPTION
This solves the problem when a vector instead of a data.frame is assigned to `metadata_given` when there is only one column in the initial metadata (#38).